### PR TITLE
AppVeyor specific project config

### DIFF
--- a/CollapseLevel.sln
+++ b/CollapseLevel.sln
@@ -7,10 +7,13 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CollapseLevel", "CollapseLe
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		AppVeyor|Any CPU = AppVeyor|Any CPU
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0FA932B1-A271-49E5-9906-15D098940C31}.AppVeyor|Any CPU.ActiveCfg = AppVeyor|Any CPU
+		{0FA932B1-A271-49E5-9906-15D098940C31}.AppVeyor|Any CPU.Build.0 = AppVeyor|Any CPU
 		{0FA932B1-A271-49E5-9906-15D098940C31}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0FA932B1-A271-49E5-9906-15D098940C31}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0FA932B1-A271-49E5-9906-15D098940C31}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/CollapseLevel/CollapseLevel.csproj
+++ b/CollapseLevel/CollapseLevel.csproj
@@ -8,14 +8,16 @@
     </NuGetPackageImportStamp>
     <UseCodebase>true</UseCodebase>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(IsAppveyorBuild)' != 'true' ">
-    <SignAssembly>true</SignAssembly>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(IsAppveyorBuild)' != 'true' ">
-    <AssemblyOriginatorKeyFile>CollapseLevelKey.pfx</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
   <PropertyGroup>
     <DelaySign>false</DelaySign>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'AppVeyor|AnyCPU'">
+    <OutputPath>bin\AppVeyor\</OutputPath>
+    <DeployExtension>False</DeployExtension>
+    <CreateVsixContainer>False</CreateVsixContainer>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -35,8 +37,6 @@
     <IncludeDebugSymbolsInLocalVSIXDeployment>true</IncludeDebugSymbolsInLocalVSIXDeployment>
     <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>
     <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
-    <CreateVsixContainer>True</CreateVsixContainer>
-    <DeployExtension>True</DeployExtension>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -54,6 +54,8 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>CollapseLevelKey.pfx</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Core\TextViewRegistry.cs" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,9 @@ environment:
 
 image: Visual Studio 2017
 
+configuration:
+  - AppVeyor
+
 before_build:
 - nuget restore
 


### PR DESCRIPTION
CI builds are much quicker without creating VSIX containers.